### PR TITLE
Feat: added readTask API

### DIFF
--- a/prisma/migrations/20240618234402_added_is_read_column_on_task_table/migration.sql
+++ b/prisma/migrations/20240618234402_added_is_read_column_on_task_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "isRead" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -184,6 +184,7 @@ model Task {
   Collaborators            Collaborators[]
   TaskWatcher              TaskWatcher[]
   TaskProjectNotifications TaskProjectNotifications[]
+  isRead                   Boolean                    @default(false)
 }
 
 model Collaborators {

--- a/src/task/task.controller.ts
+++ b/src/task/task.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Get,
   Query,
+  Patch,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { UtilityService } from 'lib/utility.service';
@@ -103,4 +104,25 @@ export class TaskController {
       });
     }
   }
+
+  @Patch('/read')
+  async readTask(
+  @NestResponse() response: Response,
+  @Query('id') taskId: string,
+) {
+  try {
+    const taskInformation = await this.taskService.readTask({ id: taskId });
+    return response.status(HttpStatus.OK).json({
+      message: 'Task successfully read.',
+      taskInformation,
+    });
+  } catch (error) {
+    return response.status(HttpStatus.BAD_REQUEST).json({
+      status: HttpStatus.BAD_REQUEST,
+      error: 'Bad Request',
+      message: error.message,
+    });
+  }
+}
+
 }

--- a/src/task/task.service.ts
+++ b/src/task/task.service.ts
@@ -402,4 +402,26 @@ export class TaskService {
     });
     return taskInformation;
   }
+
+  async readTask(taskFilter: { id: string }) {
+    const task = await this.getTaskById(taskFilter);
+
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${taskFilter.id} not found.`);
+    }
+
+    const updateParameters: Prisma.TaskUpdateInput = {
+      isRead: true,
+    };
+
+    const readTask = await this.prisma.task.update({
+      where: { id: task.id },
+      data: updateParameters,
+    });   
+
+    const taskInformation = await this.prisma.task.findUnique({
+      where: readTask,
+    });
+    return taskInformation;  
+  }
 }


### PR DESCRIPTION
### Related Tickets
- https://trello.com/c/8j0Rx6Go/8-dashboard-isread

### Expected Result
- The user should be able to change the value of isRead column from false to true.

### Summary of Changes
- Added "isRead" column on task table.
- Created a migration for the task table changes.
- Added a method named "readTask" on TaskService.
- Added a controller for the readTask method on TaskController.

### Local Testing


https://github.com/primia3d/ante-backends/assets/95896113/d340aad0-85bc-416d-99f1-9f05f31b5910

